### PR TITLE
给显示的登录二维码添加一个白色背景图，并且把二维码放大，提高扫码效率 (#344)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,7 +118,6 @@ test/
 cookies/
 *.cookies
 qr_code.png
-
 # jupyter
 .ipynb_checkpoints
 /test/

--- a/jd_spider_requests.py
+++ b/jd_spider_requests.py
@@ -19,7 +19,9 @@ from util import (
     response_status,
     save_image,
     open_image,
+    add_bg_for_qr,
     email
+
 )
 
 
@@ -161,7 +163,7 @@ class QrLogin:
         url = 'https://qr.m.jd.com/show'
         payload = {
             'appid': 133,
-            'size': 147,
+            'size': 300,
             't': str(int(time.time() * 1000)),
         }
         headers = {
@@ -176,10 +178,10 @@ class QrLogin:
 
         save_image(resp, self.qrcode_img_file)
         logger.info('二维码获取成功，请打开京东APP扫描')
-        open_image(self.qrcode_img_file)
+
+        open_image(add_bg_for_qr(self.qrcode_img_file))
         if global_config.getRaw('messenger', 'email_enable') == 'true':
             email.send('二维码获取成功，请打开京东APP扫描', "<img src='cid:qr_code.png'>", [email.mail_user], 'qr_code.png')
-
         return True
 
     def _get_qrcode_ticket(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ idna==2.9
 lxml==4.5.1
 requests==2.23.0
 urllib3==1.25.9
+Pillow~=8.0.1

--- a/util.py
+++ b/util.py
@@ -4,14 +4,12 @@ import requests
 import os
 import time
 import smtplib
-
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.mime.image import MIMEImage
 
 from config import global_config
 from jd_logger import logger
-
 
 USER_AGENTS = [
     "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36",
@@ -64,7 +62,7 @@ USER_AGENTS = [
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17",
     "Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.15 (KHTML, like Gecko) Chrome/24.0.1295.0 Safari/537.15",
     "Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.14 (KHTML, like Gecko) Chrome/24.0.1292.0 Safari/537.14"
-    ]
+]
 
 
 def parse_json(s):
@@ -88,11 +86,11 @@ def send_wechat(message):
     """推送信息到微信"""
     url = 'http://sc.ftqq.com/{}.send'.format(global_config.getRaw('messenger', 'sckey'))
     payload = {
-        "text":'抢购结果',
+        "text": '抢购结果',
         "desp": message
     }
     headers = {
-        'User-Agent':global_config.getRaw('config', 'DEFAULT_USER_AGENT')
+        'User-Agent': global_config.getRaw('config', 'DEFAULT_USER_AGENT')
     }
     requests.get(url, params=payload, headers=headers)
 
@@ -121,6 +119,23 @@ def save_image(resp, image_file):
     with open(image_file, 'wb') as f:
         for chunk in resp.iter_content(chunk_size=1024):
             f.write(chunk)
+
+
+def add_bg_for_qr(qr_path):
+    try:
+        from PIL import Image
+        qr = Image.open(qr_path)
+        w = qr.width
+        h = qr.width
+        bg = Image.new("RGB", (w * 2, h * 2), (255, 255, 255))
+        result = Image.new(bg.mode, (w * 2, h * 2))
+        result.paste(bg, box=(0, 0))
+        result.paste(qr, box=(int(w / 2), int(h / 2)))
+        result.save("qr_code.png")
+        return os.path.abspath("qr_code.png")
+    except ImportError:
+        logger.info("加载PIL失败，不对登录二维码进行优化，请查看requirements.txt")
+        return qr_path
 
 
 class Email():
@@ -185,4 +200,4 @@ email = Email(
     mail_host=global_config.getRaw('messenger', 'email_host'),
     mail_user=global_config.getRaw('messenger', 'email_user'),
     mail_pwd=global_config.getRaw('messenger', 'email_pwd'),
-    )
+)

--- a/util.py
+++ b/util.py
@@ -127,7 +127,7 @@ def add_bg_for_qr(qr_path):
         qr = Image.open(qr_path)
         w = qr.width
         h = qr.width
-        bg = Image.new("RGB", (w * 2, h * 2), (255, 255, 255))
+        bg = Image.new("RGBA", (w * 2, h * 2), (255, 255, 255))
         result = Image.new(bg.mode, (w * 2, h * 2))
         result.paste(bg, box=(0, 0))
         result.paste(qr, box=(int(w / 2), int(h / 2)))


### PR DESCRIPTION
* 1.环境：
Ubuntu18.04
2.修改：
给显示的登录二维码添加一个白色背景图，并且把二维码放大。如果没有安装pillow，就不做图片处理。
3.原因：
因为原来的显示的登录二维码图片过小，这样打开显示边框都是黑色的，导致app会识别不出来，添加白色背景后，可以让app立马识别登录

Co-authored-by: kk <smallkangzi@qq.com>